### PR TITLE
Add example with a custom theme chart (in the style of The Economist)

### DIFF
--- a/demo/components/nav.jsx
+++ b/demo/components/nav.jsx
@@ -49,12 +49,12 @@ class Nav extends React.Component {
         }
       },
       active: {
-        border: "none",
+        borderBottom: "none",
         boxShadow: "none",
         color: VictorySettings.whiteSand,
         cursor: "default",
         ":hover": {
-          border: "none"
+          borderBottom: "none"
         }
       }
     };

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,7 +14,7 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Karla:700,400,400italic" rel="stylesheet" type="text/css">
   <!-- Fira Sans for Custom Theme Tutorial -->
-  <link href="https://fonts.googleapis.com/css?family=Fira+Sans:400,400italic,700" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Fira+Sans:300,400,400italic,700" rel="stylesheet" type="text/css">
 </head>
 <body>
   <!--[if lt IE 8]>

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,6 +13,8 @@
   <!-- Fonts -->
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Karla:700,400,400italic" rel="stylesheet" type="text/css">
+  <!-- Fira Sans for Custom Theme Tutorial -->
+  <link href="https://fonts.googleapis.com/css?family=Fira+Sans:400,400italic,700" rel="stylesheet" type="text/css">
 </head>
 <body>
   <!--[if lt IE 8]>

--- a/demo/tutorials/custom-theme.jsx
+++ b/demo/tutorials/custom-theme.jsx
@@ -295,7 +295,7 @@ class MultipleAxes extends React.Component {
             <VictoryLine
               data={[
                 {x: new Date(1999, 1, 1), y: 0},
-                {x: new Date(2014, 4, 1), y: 0}
+                {x: new Date(2014, 6, 1), y: 0}
               ]}
               domain={{
                 x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],

--- a/demo/tutorials/custom-theme.jsx
+++ b/demo/tutorials/custom-theme.jsx
@@ -9,8 +9,8 @@ class MultipleAxes extends React.Component {
   getDataSetOne() {
     return [
       {x: new Date(2000, 1, 1), y: 12},
-      {x: new Date(2000, 2, 1), y: 10},
-      {x: new Date(2000, 3, 1), y: 11},
+      {x: new Date(2000, 6, 1), y: 10},
+      {x: new Date(2000, 12, 1), y: 11},
       {x: new Date(2001, 1, 1), y: 5},
       {x: new Date(2002, 1, 1), y: 4},
       {x: new Date(2003, 1, 1), y: 6},
@@ -312,6 +312,7 @@ class MultipleAxes extends React.Component {
                 x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
                 y: [-10, 15]
               }}
+              interpolation="monotoneX"
               scale={{x: "time", y: "linear"}}
               standalone={false}
               style={styles.lineOne}
@@ -323,7 +324,7 @@ class MultipleAxes extends React.Component {
                 x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
                 y: [0, 50]
               }}
-              interpolation="linear"
+              interpolation="monotoneX"
               scale={{x: "time", y: "linear"}}
               standalone={false}
               style={styles.lineTwo}

--- a/demo/tutorials/custom-theme.jsx
+++ b/demo/tutorials/custom-theme.jsx
@@ -69,11 +69,7 @@ class MultipleAxes extends React.Component {
           strokeWidth: 1
         },
         ticks: {
-          // size: 10,
-          size: (tick) => {
-            const tickSize = tick.getFullYear() % 5 === 0 ? 10 : 5;
-            return tickSize;
-          },
+          size: 10,
           /*
           TODO: Adjust tick size based on whether the year is divisible by 5.
           I believe the following should work (but it does not):
@@ -89,28 +85,26 @@ class MultipleAxes extends React.Component {
         tickLabels: {
           fill: "black",
           fontFamily: "inherit",
-          fontSize: 12
+          fontSize: 14
         }
       },
       // DATA SET ONE
       axisOne: {
+        grid: {
+          stroke: (tick) => tick === -10 ? "transparent" : "#ffffff",
+          strokeWidth: 2
+        },
         axis: {
           stroke: BLUE_COLOR,
           strokeWidth: 0
         },
         ticks: {
-          size: 350,
-          /*
-          TODO: Do not show a tick for the start of the domain
-          size: (tick) => tick == "-10" ? 0 : 350,
-          */
-          stroke: "#ffffff",
-          strokeWidth: 2
+          strokeWidth: 0
         },
         tickLabels: {
           fill: BLUE_COLOR,
           fontFamily: "inherit",
-          fontSize: 12
+          fontSize: 14
         }
       },
       labelOne: {
@@ -132,19 +126,18 @@ class MultipleAxes extends React.Component {
           strokeWidth: 0
         },
         ticks: {
-          stroke: "#ffffff",
-          strokeWidth: 2
+          strokeWidth: 0
         },
         tickLabels: {
           fill: RED_COLOR,
           fontFamily: "inherit",
-          fontSize: 12
+          fontSize: 14
         }
       },
       labelTwo: {
         fill: RED_COLOR,
         fontFamily: "inherit",
-        fontSize: "12px",
+        fontSize: 14,
         fontStyle: "italic"
       },
       lineTwo: {
@@ -227,7 +220,7 @@ class MultipleAxes extends React.Component {
               orientation="left"
               domain={[-10, 15]}
               standalone={false}
-              offsetX={400}
+              offsetX={0}
             />
 
             <VictoryAxis dependent
@@ -277,11 +270,11 @@ class MultipleAxes extends React.Component {
 
             <VictoryLine
               data={[
-                {x: new Date(2000, 1, 1), y: 0},
-                {x: new Date(2014, 1, 1), y: 0}
+                {x: new Date(1999, 1, 1), y: 0},
+                {x: new Date(2014, 4, 1), y: 0}
               ]}
               domain={{
-                x: [new Date(2000, 1, 1), new Date(2015, 1, 1)],
+                x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
                 y: [-10, 15]
               }}
               standalone={false}
@@ -291,7 +284,7 @@ class MultipleAxes extends React.Component {
             <VictoryLine
               data={dataSetOne}
               domain={{
-                x: [new Date(2000, 1, 1), new Date(2015, 1, 1)],
+                x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
                 y: [-10, 15]
               }}
               interpolation="linear"
@@ -302,7 +295,7 @@ class MultipleAxes extends React.Component {
             <VictoryLine
               data={dataSetTwo}
               domain={{
-                x: [new Date(2000, 1, 1), new Date(2015, 1, 1)],
+                x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
                 y: [0, 50]
               }}
               interpolation="linear"

--- a/demo/tutorials/custom-theme.jsx
+++ b/demo/tutorials/custom-theme.jsx
@@ -52,11 +52,16 @@ class MultipleAxes extends React.Component {
       parent: {
         boxSizing: "border-box",
         display: "inline",
-        padding: "70px 10px 20px 10px",
+        padding: 0,
         backgroundColor: BABY_BLUE_COLOR,
         fontFamily: "'Fira Sans', sans-serif",
         width: "100%",
         height: "auto"
+      },
+      labelNumber: {
+        fill: "#ffffff",
+        fontFamily: "inherit",
+        fontSize: "14px"
       },
       axisYears: {
         axis: {
@@ -64,7 +69,11 @@ class MultipleAxes extends React.Component {
           strokeWidth: 1
         },
         ticks: {
-          size: 10,
+          // size: 10,
+          size: (tick) => {
+            const tickSize = tick.getFullYear() % 5 === 0 ? 10 : 5;
+            return tickSize;
+          },
           /*
           TODO: Adjust tick size based on whether the year is divisible by 5.
           I believe the following should work (but it does not):
@@ -162,9 +171,23 @@ class MultipleAxes extends React.Component {
     return (
       <div>
         <h1>Custom Theme</h1>
-        <svg style={styles.parent} viewBox="0 0 450 300">
+        <svg style={styles.parent} viewBox="0 0 450 350">
+          <rect x="0" y="0" width="10" height="30" fill="#f01616"/>
+
+          <rect x="420" y="10" width="20" height="20" fill="#458ca8" />
+
           <VictoryLabel
-            x={25} y={-15}
+            x={430} y={27}
+            textAnchor="middle"
+            verticalAnchor="end"
+            lineHeight={1}
+            style={styles.labelNumber}
+          >
+            {"1"}
+          </VictoryLabel>
+
+          <VictoryLabel
+            x={25} y={15}
             textAnchor="start"
             verticalAnchor="start"
             lineHeight={1.2}
@@ -178,23 +201,8 @@ class MultipleAxes extends React.Component {
             {"An outlook"}
           </VictoryLabel>
 
-          <VictoryAxis dependent
-            style={styles.axisOne}
-            orientation="left"
-            domain={[-10, 15]}
-            standalone={false}
-            offsetX={400}
-          />
-
-          <VictoryAxis dependent
-            style={styles.axisTwo}
-            orientation="right"
-            domain={[0, 50]}
-            standalone={false}
-          />
-
           <VictoryLabel
-            x={25} y={40}
+            x={25} y={70}
             textAnchor="start"
             verticalAnchor="end"
             lineHeight={1.2}
@@ -204,7 +212,7 @@ class MultipleAxes extends React.Component {
           </VictoryLabel>
 
           <VictoryLabel
-            x={425} y={40}
+            x={425} y={70}
             textAnchor="end"
             verticalAnchor="end"
             lineHeight={1.2}
@@ -213,78 +221,95 @@ class MultipleAxes extends React.Component {
             {"Dinosaur exports\n $bn"}
           </VictoryLabel>
 
-          <VictoryAxis
-            style={styles.axisYears}
-            orientation="bottom"
-            standalone={false}
-            scale="time"
-            tickCount={4}
-            tickValues={[
-              new Date(1999, 1, 1),
-              new Date(2000, 1, 1),
-              new Date(2001, 1, 1),
-              new Date(2002, 1, 1),
-              new Date(2003, 1, 1),
-              new Date(2004, 1, 1),
-              new Date(2005, 1, 1),
-              new Date(2006, 1, 1),
-              new Date(2007, 1, 1),
-              new Date(2008, 1, 1),
-              new Date(2009, 1, 1),
-              new Date(2010, 1, 1),
-              new Date(2011, 1, 1),
-              new Date(2012, 1, 1),
-              new Date(2013, 1, 1),
-              new Date(2014, 1, 1),
-              new Date(2015, 1, 1),
-              new Date(2016, 1, 1)
-            ]}
-            tickFormat={
-              (x) => {
-                if (x.getFullYear() === 2000) {
-                  return x.getFullYear();
-                }
-                if (x.getFullYear() % 5 === 0) {
-                  return x.getFullYear().toString().slice(2);
+          <g transform={"translate(0, 40)"}>
+            <VictoryAxis dependent
+              style={styles.axisOne}
+              orientation="left"
+              domain={[-10, 15]}
+              standalone={false}
+              offsetX={400}
+            />
+
+            <VictoryAxis dependent
+              style={styles.axisTwo}
+              orientation="right"
+              domain={[0, 50]}
+              standalone={false}
+            />
+
+            <VictoryAxis
+              style={styles.axisYears}
+              orientation="bottom"
+              standalone={false}
+              scale="time"
+              tickCount={4}
+              tickValues={[
+                new Date(1999, 1, 1),
+                new Date(2000, 1, 1),
+                new Date(2001, 1, 1),
+                new Date(2002, 1, 1),
+                new Date(2003, 1, 1),
+                new Date(2004, 1, 1),
+                new Date(2005, 1, 1),
+                new Date(2006, 1, 1),
+                new Date(2007, 1, 1),
+                new Date(2008, 1, 1),
+                new Date(2009, 1, 1),
+                new Date(2010, 1, 1),
+                new Date(2011, 1, 1),
+                new Date(2012, 1, 1),
+                new Date(2013, 1, 1),
+                new Date(2014, 1, 1),
+                new Date(2015, 1, 1),
+                new Date(2016, 1, 1)
+              ]}
+              tickFormat={
+                (x) => {
+                  if (x.getFullYear() === 2000) {
+                    return x.getFullYear();
+                  }
+                  if (x.getFullYear() % 5 === 0) {
+                    return x.getFullYear().toString().slice(2);
+                  }
                 }
               }
-            }
-          />
+            />
 
-          <VictoryLine
-            data={[
-              {x: new Date(2000, 1, 1), y: 0},
-              {x: new Date(2014, 1, 1), y: 0}
-            ]}
-            domain={{
-              x: [new Date(2000, 1, 1), new Date(2015, 1, 1)],
-              y: [-10, 15]
-            }}
-            standalone={false}
-            style={styles.lineThree}
-          />
+            <VictoryLine
+              data={[
+                {x: new Date(2000, 1, 1), y: 0},
+                {x: new Date(2014, 1, 1), y: 0}
+              ]}
+              domain={{
+                x: [new Date(2000, 1, 1), new Date(2015, 1, 1)],
+                y: [-10, 15]
+              }}
+              standalone={false}
+              style={styles.lineThree}
+            />
 
-          <VictoryLine
-            data={dataSetOne}
-            domain={{
-              x: [new Date(2000, 1, 1), new Date(2015, 1, 1)],
-              y: [-10, 15]
-            }}
-            interpolation="linear"
-            standalone={false}
-            style={styles.lineOne}
-          />
+            <VictoryLine
+              data={dataSetOne}
+              domain={{
+                x: [new Date(2000, 1, 1), new Date(2015, 1, 1)],
+                y: [-10, 15]
+              }}
+              interpolation="linear"
+              standalone={false}
+              style={styles.lineOne}
+            />
 
-          <VictoryLine
-            data={dataSetTwo}
-            domain={{
-              x: [new Date(2000, 1, 1), new Date(2015, 1, 1)],
-              y: [0, 50]
-            }}
-            interpolation="linear"
-            standalone={false}
-            style={styles.lineTwo}
-          />
+            <VictoryLine
+              data={dataSetTwo}
+              domain={{
+                x: [new Date(2000, 1, 1), new Date(2015, 1, 1)],
+                y: [0, 50]
+              }}
+              interpolation="linear"
+              standalone={false}
+              style={styles.lineTwo}
+            />
+          </g>
         </svg>
       </div>
     );

--- a/demo/tutorials/custom-theme.jsx
+++ b/demo/tutorials/custom-theme.jsx
@@ -6,50 +6,190 @@ import { VictoryAxis, VictoryLine } from "victory-chart";
 import { VictoryLabel } from "victory-core";
 
 class MultipleAxes extends React.Component {
+  getDataSetOne() {
+    return [
+      {x: new Date(2000, 1, 1), y: 12},
+      {x: new Date(2000, 2, 1), y: 10},
+      {x: new Date(2000, 3, 1), y: 11},
+      {x: new Date(2001, 1, 1), y: 5},
+      {x: new Date(2002, 1, 1), y: 4},
+      {x: new Date(2003, 1, 1), y: 6},
+      {x: new Date(2004, 1, 1), y: 5},
+      {x: new Date(2005, 1, 1), y: 7},
+      {x: new Date(2006, 1, 1), y: 8},
+      {x: new Date(2007, 1, 1), y: 9},
+      {x: new Date(2008, 1, 1), y: -8.5},
+      {x: new Date(2009, 1, 1), y: -9},
+      {x: new Date(2010, 1, 1), y: 5},
+      {x: new Date(2013, 1, 1), y: 1},
+      {x: new Date(2014, 1, 1), y: 2},
+      {x: new Date(2015, 1, 1), y: -5}
+    ];
+  }
+
+  getDataSetTwo() {
+    return [
+      {x: new Date(2000, 1, 1), y: 5},
+      {x: new Date(2003, 1, 1), y: 6},
+      {x: new Date(2004, 1, 1), y: 4},
+      {x: new Date(2005, 1, 1), y: 10},
+      {x: new Date(2006, 1, 1), y: 12},
+      {x: new Date(2007, 2, 1), y: 48},
+      {x: new Date(2008, 1, 1), y: 19},
+      {x: new Date(2009, 1, 1), y: 31},
+      {x: new Date(2011, 1, 1), y: 49},
+      {x: new Date(2014, 1, 1), y: 40},
+      {x: new Date(2015, 1, 1), y: 21}
+    ];
+  }
+
   getStyles() {
+    const BABY_BLUE_COLOR = "#ccdee8";
+    const BLUE_COLOR = "#00a3de";
+    const RED_COLOR = "#7c270b";
+
     return {
       parent: {
         boxSizing: "border-box",
-        display: "block",
+        display: "inline",
+        padding: "70px 10px 20px 10px",
+        backgroundColor: BABY_BLUE_COLOR,
+        fontFamily: "'Fira Sans', sans-serif",
         width: "100%",
-        height: "100%",
-        padding: 50
+        height: "auto"
+      },
+      axisYears: {
+        axis: {
+          stroke: "black",
+          strokeWidth: 1
+        },
+        ticks: {
+          size: 10,
+          /*
+          TODO: Adjust tick size based on whether the year is divisible by 5.
+          I believe the following should work (but it does not):
+          ticks: {
+            size: (tick) => {
+              const tickSize = tick.getFullYear() % 5 === 0 ? 10 : 5;
+              return tickSize;
+            }
+          */
+          stroke: "black",
+          strokeWidth: 1
+        },
+        tickLabels: {
+          fill: "black",
+          fontFamily: "inherit",
+          fontSize: 12
+        }
+      },
+      // DATA SET ONE
+      axisOne: {
+        axis: {
+          stroke: BLUE_COLOR,
+          strokeWidth: 0
+        },
+        ticks: {
+          size: 350,
+          /*
+          TODO: Do not show a tick for the start of the domain
+          size: (tick) => tick == "-10" ? 0 : 350,
+          */
+          stroke: "#ffffff",
+          strokeWidth: 2
+        },
+        tickLabels: {
+          fill: BLUE_COLOR,
+          fontFamily: "inherit",
+          fontSize: 12
+        }
+      },
+      labelOne: {
+        fill: BLUE_COLOR,
+        fontFamily: "inherit",
+        fontSize: "12px",
+        fontStyle: "italic"
+      },
+      lineOne: {
+        data: {
+          stroke: BLUE_COLOR,
+          strokeWidth: 3
+        }
+      },
+      // DATA SET TWO
+      axisTwo: {
+        axis: {
+          stroke: RED_COLOR,
+          strokeWidth: 0
+        },
+        ticks: {
+          stroke: "#ffffff",
+          strokeWidth: 2
+        },
+        tickLabels: {
+          fill: RED_COLOR,
+          fontFamily: "inherit",
+          fontSize: 12
+        }
+      },
+      labelTwo: {
+        fill: RED_COLOR,
+        fontFamily: "inherit",
+        fontSize: "12px",
+        fontStyle: "italic"
+      },
+      lineTwo: {
+        data: {
+          stroke: RED_COLOR,
+          strokeWidth: 3
+        }
+      },
+      // HORIZONTAL LINE
+      lineThree: {
+        data: {
+          stroke: "#e95f46",
+          strokeWidth: 2
+        }
       }
     };
   }
 
   render() {
     const styles = this.getStyles();
-    const blueColor = "#00a3de";
+    const dataSetOne = this.getDataSetOne();
+    const dataSetTwo = this.getDataSetTwo();
 
     return (
       <div>
         <h1>Custom Theme</h1>
-
-        <svg style={styles.parent} viewBox="0 0 500 300">
-          <VictoryAxis
+        <svg style={styles.parent} viewBox="0 0 450 300">
+          <VictoryLabel
+            x={25} y={-15}
+            textAnchor="start"
+            verticalAnchor="start"
+            lineHeight={1.2}
             style={{
-              data: {
-                strokeWidth: 2
-              },
-              labels: {
-                fontSize: 16
-              }
+              fill: "#000000",
+              fontFamily: "inherit",
+              fontSize: "18px",
+              fontWeight: "bold"
             }}
-            orientation="bottom"
-            domain={[0, 20]}
-            label="Years"
+          >
+            {"An outlook"}
+          </VictoryLabel>
+
+          <VictoryAxis dependent
+            style={styles.axisOne}
+            orientation="left"
+            domain={[-10, 15]}
             standalone={false}
+            offsetX={400}
           />
 
           <VictoryAxis dependent
-            style={{
-              axis: {stroke: blueColor, strokeWidth: 2},
-              ticks: {stroke: blueColor},
-              tickLabels: {fontSize: 12}
-            }}
-            orientation="left"
-            domain={[-10, 15]}
+            style={styles.axisTwo}
+            orientation="right"
+            domain={[0, 50]}
             standalone={false}
           />
 
@@ -57,32 +197,93 @@ class MultipleAxes extends React.Component {
             x={25} y={40}
             textAnchor="start"
             verticalAnchor="end"
-            lineHeight={1}
-            style={{
-              fill: blueColor,
-              fontSize: "12px",
-              fontStyle: "italic"
-            }}
+            lineHeight={1.2}
+            style={styles.labelOne}
           >
-            {"GDP \n % change on a year earlier"}
+            {"Economy \n % change on a year earlier"}
           </VictoryLabel>
 
-          <VictoryAxis dependent
-            style={{
-              axis: {stroke: "blue", strokeWidth: 2},
-              ticks: {stroke: "blue"},
-              tickLabels: {fontSize: 12}
+          <VictoryLabel
+            x={425} y={40}
+            textAnchor="end"
+            verticalAnchor="end"
+            lineHeight={1.2}
+            style={styles.labelTwo}
+          >
+            {"Dinosaur exports\n $bn"}
+          </VictoryLabel>
+
+          <VictoryAxis
+            style={styles.axisYears}
+            orientation="bottom"
+            standalone={false}
+            scale="time"
+            tickCount={4}
+            tickValues={[
+              new Date(1999, 1, 1),
+              new Date(2000, 1, 1),
+              new Date(2001, 1, 1),
+              new Date(2002, 1, 1),
+              new Date(2003, 1, 1),
+              new Date(2004, 1, 1),
+              new Date(2005, 1, 1),
+              new Date(2006, 1, 1),
+              new Date(2007, 1, 1),
+              new Date(2008, 1, 1),
+              new Date(2009, 1, 1),
+              new Date(2010, 1, 1),
+              new Date(2011, 1, 1),
+              new Date(2012, 1, 1),
+              new Date(2013, 1, 1),
+              new Date(2014, 1, 1),
+              new Date(2015, 1, 1),
+              new Date(2016, 1, 1)
+            ]}
+            tickFormat={
+              (x) => {
+                if (x.getFullYear() === 2000) {
+                  return x.getFullYear();
+                }
+                if (x.getFullYear() % 5 === 0) {
+                  return x.getFullYear().toString().slice(2);
+                }
+              }
+            }
+          />
+
+          <VictoryLine
+            data={[
+              {x: new Date(2000, 1, 1), y: 0},
+              {x: new Date(2014, 1, 1), y: 0}
+            ]}
+            domain={{
+              x: [new Date(2000, 1, 1), new Date(2015, 1, 1)],
+              y: [-10, 15]
             }}
-            orientation="right"
-            domain={[-0.8, 0.8]}
-            label="High Frequency"
             standalone={false}
+            style={styles.lineThree}
           />
+
           <VictoryLine
+            data={dataSetOne}
+            domain={{
+              x: [new Date(2000, 1, 1), new Date(2015, 1, 1)],
+              y: [-10, 15]
+            }}
+            interpolation="linear"
             standalone={false}
+            style={styles.lineOne}
           />
+
           <VictoryLine
+            data={dataSetTwo}
+            domain={{
+              x: [new Date(2000, 1, 1), new Date(2015, 1, 1)],
+              y: [0, 50]
+            }}
+            interpolation="linear"
             standalone={false}
+            style={styles.lineTwo}
           />
         </svg>
       </div>

--- a/demo/tutorials/custom-theme.jsx
+++ b/demo/tutorials/custom-theme.jsx
@@ -180,7 +180,6 @@ class MultipleAxes extends React.Component {
             x={430} y={27}
             textAnchor="middle"
             verticalAnchor="end"
-            lineHeight={1}
             style={styles.labelNumber}
           >
             {"1"}
@@ -203,7 +202,6 @@ class MultipleAxes extends React.Component {
 
           <VictoryLabel
             x={25} y={70}
-            textAnchor="start"
             verticalAnchor="end"
             lineHeight={1.2}
             style={styles.labelOne}
@@ -226,7 +224,6 @@ class MultipleAxes extends React.Component {
               x={37} y={161}
               textAnchor="middle"
               verticalAnchor="end"
-              lineHeight={1}
               style={styles.axisOneCustomLabel}
             >
               {"+"}
@@ -236,7 +233,6 @@ class MultipleAxes extends React.Component {
               x={37} y={199}
               textAnchor="middle"
               verticalAnchor="end"
-              lineHeight={1}
               style={styles.axisOneCustomLabel}
             >
               {"-"}
@@ -261,11 +257,9 @@ class MultipleAxes extends React.Component {
             />
 
             <VictoryAxis
-              orientation="bottom"
               scale="time"
               standalone={false}
               style={styles.axisYears}
-              tickCount={4}
               tickValues={[
                 new Date(1999, 1, 1),
                 new Date(2000, 1, 1),
@@ -318,7 +312,6 @@ class MultipleAxes extends React.Component {
                 x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
                 y: [-10, 15]
               }}
-              interpolation="linear"
               scale={{x: "time", y: "linear"}}
               standalone={false}
               style={styles.lineOne}

--- a/demo/tutorials/custom-theme.jsx
+++ b/demo/tutorials/custom-theme.jsx
@@ -85,7 +85,7 @@ class MultipleAxes extends React.Component {
         tickLabels: {
           fill: "black",
           fontFamily: "inherit",
-          fontSize: 14
+          fontSize: 16
         }
       },
       // DATA SET ONE
@@ -104,20 +104,26 @@ class MultipleAxes extends React.Component {
         tickLabels: {
           fill: BLUE_COLOR,
           fontFamily: "inherit",
-          fontSize: 14
+          fontSize: 16
         }
       },
       labelOne: {
         fill: BLUE_COLOR,
         fontFamily: "inherit",
-        fontSize: "12px",
+        fontSize: 12,
         fontStyle: "italic"
       },
       lineOne: {
         data: {
           stroke: BLUE_COLOR,
-          strokeWidth: 3
+          strokeWidth: 4.5
         }
+      },
+      axisOneCustomLabel: {
+        fill: BLUE_COLOR,
+        fontFamily: "inherit",
+        fontWeight: 300,
+        fontSize: 21
       },
       // DATA SET TWO
       axisTwo: {
@@ -131,19 +137,19 @@ class MultipleAxes extends React.Component {
         tickLabels: {
           fill: RED_COLOR,
           fontFamily: "inherit",
-          fontSize: 14
+          fontSize: 16
         }
       },
       labelTwo: {
         fill: RED_COLOR,
         fontFamily: "inherit",
-        fontSize: 14,
+        fontSize: 12,
         fontStyle: "italic"
       },
       lineTwo: {
         data: {
           stroke: RED_COLOR,
-          strokeWidth: 3
+          strokeWidth: 4.5
         }
       },
       // HORIZONTAL LINE
@@ -164,6 +170,7 @@ class MultipleAxes extends React.Component {
     return (
       <div>
         <h1>Custom Theme</h1>
+        <br/>
         <svg style={styles.parent} viewBox="0 0 450 350">
           <rect x="0" y="0" width="10" height="30" fill="#f01616"/>
 
@@ -215,26 +222,49 @@ class MultipleAxes extends React.Component {
           </VictoryLabel>
 
           <g transform={"translate(0, 40)"}>
+            <VictoryLabel
+              x={37} y={161}
+              textAnchor="middle"
+              verticalAnchor="end"
+              lineHeight={1}
+              style={styles.axisOneCustomLabel}
+            >
+              {"+"}
+            </VictoryLabel>
+
+            <VictoryLabel
+              x={37} y={199}
+              textAnchor="middle"
+              verticalAnchor="end"
+              lineHeight={1}
+              style={styles.axisOneCustomLabel}
+            >
+              {"-"}
+            </VictoryLabel>
+
             <VictoryAxis dependent
-              style={styles.axisOne}
-              orientation="left"
               domain={[-10, 15]}
-              standalone={false}
               offsetX={0}
+              orientation="left"
+              standalone={false}
+              style={styles.axisOne}
+              tickFormat={
+                (x) => { return Math.abs(x).toString(); }
+              }
             />
 
             <VictoryAxis dependent
-              style={styles.axisTwo}
-              orientation="right"
               domain={[0, 50]}
+              orientation="right"
               standalone={false}
+              style={styles.axisTwo}
             />
 
             <VictoryAxis
-              style={styles.axisYears}
               orientation="bottom"
-              standalone={false}
               scale="time"
+              standalone={false}
+              style={styles.axisYears}
               tickCount={4}
               tickValues={[
                 new Date(1999, 1, 1),
@@ -277,6 +307,7 @@ class MultipleAxes extends React.Component {
                 x: [new Date(1999, 1, 1), new Date(2016, 1, 1)],
                 y: [-10, 15]
               }}
+              scale={{x: "time", y: "linear"}}
               standalone={false}
               style={styles.lineThree}
             />
@@ -288,6 +319,7 @@ class MultipleAxes extends React.Component {
                 y: [-10, 15]
               }}
               interpolation="linear"
+              scale={{x: "time", y: "linear"}}
               standalone={false}
               style={styles.lineOne}
             />
@@ -299,6 +331,7 @@ class MultipleAxes extends React.Component {
                 y: [0, 50]
               }}
               interpolation="linear"
+              scale={{x: "time", y: "linear"}}
               standalone={false}
               style={styles.lineTwo}
             />


### PR DESCRIPTION
The Economist uses the [Officina](https://www.myfonts.com/fonts/itc/officina-sans/) typeface, so I picked the closest free font, Fira Sans. 

I got stuck on a few items: 
- changing the tick sizes dynamically; I commented out the code that I think should work
- how to make the red horizontal line stop at the last intersection between the blue line and the `0` tick. 
- how to hide the bottom-most white horizontal tick

(Also I guess these aren’t tutorials. Should this be turned into a tutorial?)

sample:
<img width="311" alt="screen shot 2016-03-20 at 11 20 05 am" src="https://cloud.githubusercontent.com/assets/768965/15057314/11e8a824-12cb-11e6-82f3-e80276a8e937.png">
 
result:
![screen shot 2016-05-05 at 2 06 55 pm](https://cloud.githubusercontent.com/assets/768965/15057266/e05c58b4-12ca-11e6-8f04-996803923fac.png)