### PR TITLE
adding a central axis example

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -11,6 +11,7 @@ import Index from "./index";
 import MultipleAxes from "./tutorials/multiple-axes";
 import CustomTheme from "./tutorials/custom-theme";
 import CustomDataComponent from "./tutorials/custom-data-component";
+import CentralAxis from "./tutorials/custom-central-axis";
 
 const content = document.getElementById("content");
 
@@ -20,6 +21,7 @@ render((
       <Route path="multiple-axes" component={MultipleAxes} />
       <Route path="custom-theme" component={CustomTheme} />
       <Route path="custom-data-component" component={CustomDataComponent} />
+      <Route path="custom-central-axis" component={CentralAxis} />
     </Route>
   </Router>
 ), content);

--- a/demo/components/nav.jsx
+++ b/demo/components/nav.jsx
@@ -80,6 +80,11 @@ class Nav extends React.Component {
               Custom Data Component
             </RadiumLink>
           </li>
+          <li style={styles.listItem}>
+            <RadiumLink to="custom-central-axis" activeStyle={styles.active} style={styles.link}>
+              Custom Central Axis
+            </RadiumLink>
+          </li>
         </ul>
       </nav>
     );

--- a/demo/tutorials/custom-central-axis.js
+++ b/demo/tutorials/custom-central-axis.js
@@ -33,8 +33,7 @@ class CentralAxis extends React.Component {
             style={{
               axis: {strokeWidth: 1}
             }}
-            domain={[0, 500]}
-            offsetX={261}
+            offsetX={264.75}
             standalone={false}
             tickValues={[
               "Smartphone",
@@ -50,9 +49,9 @@ class CentralAxis extends React.Component {
           />
 
           <VictoryStack horizontal
-            height={400}
+            height={300}
             style={{
-              data: {width: 30},
+              data: {width: 20},
               labels: {fontSize: 11}
             }}
           >

--- a/demo/tutorials/custom-central-axis.js
+++ b/demo/tutorials/custom-central-axis.js
@@ -3,34 +3,27 @@ import Radium from "radium";
 
 // VComponents
 import { VictoryAxis, VictoryBar, VictoryStack } from "victory-chart";
+import { VictoryLabel } from "victory-core";
 
 class CentralAxis extends React.Component {
-  getStyles() {
-    return {
-      parent: {
-        boxSizing: "border-box",
-        display: "block",
-        width: "100%",
-        height: "100%",
-        padding: 50
-      },
-      copy: {
-        maxWidth: "37em"
-      }
-    };
-  }
-
   render() {
-    const styles = this.getStyles();
-
-    /* eslint-disable max-len */
     return (
       <div>
         <h1>Custom Central Axis</h1>
-        <svg style={styles.parent} viewBox="0 0 500 300">
+        <svg style={{width: "100%", height: "auto"}} viewBox="0 0 500 300">
 
           <VictoryStack horizontal
+            /* setting a symmetric domain makes it much easier to center the axis */
+            domain={{x: [-60, 60]}}
+            /*
+              When not using two adjacent Victory components without a wrapper component
+              like VictoryChart or VictoryStack width, height and padding padding must be
+              set in top level component so that they match up with each other.
+            */
             height={300}
+            width={500}
+            padding={50}
+            standalone={false}
             style={{
               data: {width: 20},
               labels: {fontSize: 11}
@@ -71,12 +64,22 @@ class CentralAxis extends React.Component {
           </VictoryStack>
 
           <VictoryAxis dependentAxis
+            height={300}
+            width={500}
+            padding={50}
             style={{
-              axis: {strokeWidth: 1, stroke: "transparent"},
+              axis: {stroke: "transparent"},
               ticks: {stroke: "transparent"},
-              tickLabels: {WebkitTransform: "translateX(30px)", fontSize: 5, fill: "black"}
+              tickLabels: {fontSize: 7, fill: "black"}
             }}
-            offsetX={264.75}
+            /*
+              Use a custom tickLabelComponent with an absolutely positioned x value
+              to position your tick labels in the center of the chart. The correct
+              y values are still provided by VictoryAxis for each tick
+            */
+            tickLabelComponent={
+              <VictoryLabel x={250} textAnchor="middle" verticalAnchor="middle"/>
+            }
             standalone={false}
             tickValues={[
               "Smartphone",
@@ -93,7 +96,6 @@ class CentralAxis extends React.Component {
         </svg>
       </div>
     );
-    /* eslint-enable max-len */
   }
 }
 

--- a/demo/tutorials/custom-central-axis.js
+++ b/demo/tutorials/custom-central-axis.js
@@ -45,7 +45,7 @@ class CentralAxis extends React.Component {
                 {x: "Tablet", y: 38},
                 {x: "Fitness Monitor", y: 12},
                 {x: "Smartwatch", y: 12},
-                {x: "Connected Surveillance Camera", y: 10},
+                {x: "Surveillance Camera", y: 10},
                 {x: "Smart Thermostat", y: 9},
                 {x: "Personal Drones", y: 6}
               ]}
@@ -62,7 +62,7 @@ class CentralAxis extends React.Component {
                 {x: "Tablet", y: 29},
                 {x: "Fitness Monitor", y: 13},
                 {x: "Smartwatch", y: 13},
-                {x: "Connected Surveillance Camera", y: 11},
+                {x: "Surveillance Camera", y: 11},
                 {x: "Smart Thermostat", y: 9},
                 {x: "Personal Drones", y: 7}
               ]}
@@ -73,7 +73,8 @@ class CentralAxis extends React.Component {
           <VictoryAxis dependentAxis
             style={{
               axis: {strokeWidth: 1, stroke: "transparent"},
-              ticks: {stroke: "transparent"}
+              ticks: {stroke: "transparent"},
+              tickLabels: {WebkitTransform: "translateX(30px)", fontSize: 5, fill: "black"}
             }}
             offsetX={264.75}
             standalone={false}
@@ -84,15 +85,12 @@ class CentralAxis extends React.Component {
               "Tablet",
               "Fitness Monitor",
               "Smartwatch",
-              "Connected Surveillance Camera",
+              "Surveillance Camera",
               "Smart Thermostat",
               "Personal Drones"
             ]}
           />
         </svg>
-        {/*<p style={styles.copy} className="Copy">
-                  This example is not original; it is based on <a href="http://blogs.mathworks.com/loren/2013/03/27/multiple-y-axes/">the Multipe Y Axes example implemented in MATLAB</a>.
-                </p>*/}
       </div>
     );
     /* eslint-enable max-len */

--- a/demo/tutorials/custom-central-axis.js
+++ b/demo/tutorials/custom-central-axis.js
@@ -1,0 +1,102 @@
+import React from "react";
+import Radium from "radium";
+
+// VComponents
+import { VictoryAxis, VictoryBar, VictoryStack } from "victory-chart";
+
+class CentralAxis extends React.Component {
+  getStyles() {
+    return {
+      parent: {
+        boxSizing: "border-box",
+        display: "block",
+        width: "100%",
+        height: "100%",
+        padding: 50
+      },
+      copy: {
+        maxWidth: "37em"
+      }
+    };
+  }
+
+  render() {
+    const styles = this.getStyles();
+
+    /* eslint-disable max-len */
+    return (
+      <div>
+        <h1>Custom Central Axis</h1>
+        <svg style={styles.parent} viewBox="0 0 500 300">
+
+          <VictoryAxis dependentAxis
+            style={{
+              axis: {strokeWidth: 1}
+            }}
+            domain={[0, 500]}
+            offsetX={261}
+            standalone={false}
+            tickValues={[
+              "Smartphone",
+              "Laptop",
+              "Television",
+              "Tablet",
+              "Fitness Monitor",
+              "Smartwatch",
+              "Connected Surveillance Camera",
+              "Smart Thermostat",
+              "Personal Drones"
+            ]}
+          />
+
+          <VictoryStack horizontal
+            height={400}
+            style={{
+              data: {width: 30},
+              labels: {fontSize: 11}
+            }}
+          >
+            <VictoryBar
+              style={{data: {fill: "tomato"}, labels: {padding: -5}}}
+              data={[
+                {x: "Smartphone", y: 57},
+                {x: "Laptop", y: 36},
+                {x: "Televsion", y: 38},
+                {x: "Tablet", y: 38},
+                {x: "Fitness Monitor", y: 12},
+                {x: "Smartwatch", y: 12},
+                {x: "Connected Surveillance Camera", y: 10},
+                {x: "Smart Thermostat", y: 9},
+                {x: "Personal Drones", y: 6}
+              ]}
+              x={"x"}
+              y={(data) => (-Math.abs(data.y))}
+              labels={(data) => (`${Math.abs(data.y)}%`)}
+            />
+            <VictoryBar
+              style={{data: {fill: "orange"}}}
+              data={[
+                {x: "Smartphone", y: 48},
+                {x: "Laptop", y: 30},
+                {x: "Television", y: 30},
+                {x: "Tablet", y: 29},
+                {x: "Fitness Monitor", y: 13},
+                {x: "Smartwatch", y: 13},
+                {x: "Connected Surveillance Camera", y: 11},
+                {x: "Smart Thermostat", y: 9},
+                {x: "Personal Drones", y: 7}
+              ]}
+              labels={(data) => (`${Math.abs(data.y)}%`)}
+            />
+          </VictoryStack>
+        </svg>
+        {/*<p style={styles.copy} className="Copy">
+                  This example is not original; it is based on <a href="http://blogs.mathworks.com/loren/2013/03/27/multiple-y-axes/">the Multipe Y Axes example implemented in MATLAB</a>.
+                </p>*/}
+      </div>
+    );
+    /* eslint-enable max-len */
+  }
+}
+
+export default Radium(CentralAxis); // eslint-disable-line new-cap

--- a/demo/tutorials/custom-central-axis.js
+++ b/demo/tutorials/custom-central-axis.js
@@ -29,25 +29,6 @@ class CentralAxis extends React.Component {
         <h1>Custom Central Axis</h1>
         <svg style={styles.parent} viewBox="0 0 500 300">
 
-          <VictoryAxis dependentAxis
-            style={{
-              axis: {strokeWidth: 1}
-            }}
-            offsetX={264.75}
-            standalone={false}
-            tickValues={[
-              "Smartphone",
-              "Laptop",
-              "Television",
-              "Tablet",
-              "Fitness Monitor",
-              "Smartwatch",
-              "Connected Surveillance Camera",
-              "Smart Thermostat",
-              "Personal Drones"
-            ]}
-          />
-
           <VictoryStack horizontal
             height={300}
             style={{
@@ -88,6 +69,26 @@ class CentralAxis extends React.Component {
               labels={(data) => (`${Math.abs(data.y)}%`)}
             />
           </VictoryStack>
+
+          <VictoryAxis dependentAxis
+            style={{
+              axis: {strokeWidth: 1, stroke: "transparent"},
+              ticks: {stroke: "transparent"}
+            }}
+            offsetX={264.75}
+            standalone={false}
+            tickValues={[
+              "Smartphone",
+              "Laptop",
+              "Television",
+              "Tablet",
+              "Fitness Monitor",
+              "Smartwatch",
+              "Connected Surveillance Camera",
+              "Smart Thermostat",
+              "Personal Drones"
+            ]}
+          />
         </svg>
         {/*<p style={styles.copy} className="Copy">
                   This example is not original; it is based on <a href="http://blogs.mathworks.com/loren/2013/03/27/multiple-y-axes/">the Multipe Y Axes example implemented in MATLAB</a>.


### PR DESCRIPTION
This is in reference to #8 and creates a horizontal stacked bar chart with positive and negative values along a central axis. The data displays wonderfully and so do the percentage labels, but I'm having a difficult time with the axis - need to figure out how to make the axis labels 1) display appropriately on the appropriate data bar 2) show up in front of the data instead of behind it 3) center on the axis instead of be offset to one side. Ideally, the axis itself will remain behind the data while the labels come in front.