### PR TITLE
Update class name

### DIFF
--- a/docs/custom-central-axis/docs.js
+++ b/docs/custom-central-axis/docs.js
@@ -14,7 +14,7 @@ import Example from "raw!./source.example";
 class CustomCentralAxisTutorial extends React.Component {
   render() {
     return (
-      <div className="Ecology playgroundsMaxHeight">
+      <div className="Recipe">
         <h1>Custom Central Axis</h1>
         <pre>
           <div className="Interactive">

--- a/docs/custom-data-component/docs.js
+++ b/docs/custom-data-component/docs.js
@@ -21,7 +21,7 @@ class CustomDataComponentTutorial extends React.Component {
   /* eslint-disable max-len */
   render() {
     return (
-      <div className="Ecology playgroundsMaxHeight">
+      <div className="Recipe">
         <h1>Custom Data Component</h1>
         <pre>
           <div className="Interactive">

--- a/docs/custom-styles/docs.js
+++ b/docs/custom-styles/docs.js
@@ -15,7 +15,7 @@ import Example from "raw!./source.example";
 class CustomStylesTutorial extends React.Component {
   render() {
     return (
-      <div className="Ecology playgroundsMaxHeight">
+      <div className="Recipe">
         <h1>Custom Styles</h1>
         <p>The following chart has multiple axes, a time axis, and a very specific look.</p>
         <pre>

--- a/docs/multiple-axes/docs.js
+++ b/docs/multiple-axes/docs.js
@@ -18,7 +18,7 @@ class MultipleAxesTutorial extends React.Component {
   /* eslint-disable max-len */
   render() {
     return (
-      <div className="Ecology playgroundsMaxHeight">
+      <div className="Recipe">
         <h1>Multiple Axes</h1>
         <pre>
           <div className="Interactive">

--- a/docs/tooltip/docs.js
+++ b/docs/tooltip/docs.js
@@ -21,7 +21,7 @@ class TooltipTutorial extends React.Component {
   /* eslint-disable max-len */
   render() {
     return (
-      <div className="Ecology playgroundsMaxHeight">
+      <div className="Recipe">
         <h1>Tooltip</h1>
         <p>
           A custom tooltip is achieved by creating a <code>Flyout</code> React component and passing it as <code>labelComponent</code> to <code>VictoryScatter</code>.


### PR DESCRIPTION
Styling `Ecology` components requires a dependency on class names and DOM structure. 
While `victory-examples` is not using `Ecology`, if it matches the structure, then the docs will appear seamless with the recipes. Instead of imposing that structure here, I want to move the wrapper class names to `victory-docs`. A generic class name is used here instead. 

/cc @boygirl 